### PR TITLE
[feat] 기획서 상세 조회 API 구현

### DIFF
--- a/src/main/java/trend/project/api/code/status/ErrorStatus.java
+++ b/src/main/java/trend/project/api/code/status/ErrorStatus.java
@@ -19,7 +19,13 @@ public enum ErrorStatus implements BaseErrorCode {
 
 
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER2001", "사용자가 없습니다."),
-    COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, "COMPANY3001", "사용자가 없습니다.");
+    COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, "COMPANY3001", "사용자가 없습니다."),
+    
+    //기획서 관련 오류
+    PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAN4001", "기획서를 찾을 수 없습니다."),
+    PLAN_POSTER_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAN4002", "포스터를 찾을 수 없습니다."),
+    PLAN_BANNER_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAN4003", "배너를 찾을 수 없습니다."),
+    PLAN_LOCATION_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAN4004", "주소를 찾을 수 없습니다.");
 
     
     private final HttpStatus httpStatus;

--- a/src/main/java/trend/project/api/exception/handler/PlanCategoryHandler.java
+++ b/src/main/java/trend/project/api/exception/handler/PlanCategoryHandler.java
@@ -1,0 +1,12 @@
+package trend.project.api.exception.handler;
+
+import trend.project.api.code.BaseErrorCode;
+import trend.project.api.exception.GeneralException;
+
+public class PlanCategoryHandler extends GeneralException {
+    
+    public PlanCategoryHandler(BaseErrorCode baseErrorCode) {
+        
+        super(baseErrorCode);
+    }
+}

--- a/src/main/java/trend/project/converter/PlanConverter.java
+++ b/src/main/java/trend/project/converter/PlanConverter.java
@@ -1,0 +1,37 @@
+package trend.project.converter;
+
+import trend.project.domain.*;
+import trend.project.web.dto.planDTO.PlanDetailDTO;
+
+public class PlanConverter {
+    
+    public static PlanDetailDTO.PlanDetailResponseDTO toPlanDetailResponseDTO(Plan plan,
+                                                                              Member member,
+                                                                              Location location,
+                                                                              PlanPosterImage posterImage,
+                                                                              PlanBannerImage bannerImage) {
+        return PlanDetailDTO.PlanDetailResponseDTO.builder()
+                .title(plan.getTitle())
+                .category(String.valueOf(plan.getCategory()))
+                .startDate(plan.getStartDate())
+                .endDate(plan.getEndDate())
+                .target(plan.getTarget())
+                .cost(plan.getCost())
+                .content(plan.getContent())
+                .budget(plan.getBudget())
+                .likesCount(plan.getLikesCount())
+                .commentCount(plan.getCommentCount())
+                .bookmarkCount(plan.getBookmarkCount())
+                .status(plan.getStatus().name())
+                .posterUrl(posterImage.getImageLink())
+                .bannerUrl(bannerImage.getImageLink())
+                .username(member.getNickname())
+                .followerCount(member.getFollowerCount())
+                .province(location.getProvince())
+                .city(location.getCity())
+                .town(location.getTown())
+                .build();
+    }
+    
+
+}

--- a/src/main/java/trend/project/repository/planRepository/BannerImageRepository.java
+++ b/src/main/java/trend/project/repository/planRepository/BannerImageRepository.java
@@ -1,0 +1,16 @@
+package trend.project.repository.planRepository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import trend.project.domain.PlanBannerImage;
+import trend.project.domain.PlanPosterImage;
+
+import java.util.Optional;
+
+public interface BannerImageRepository extends JpaRepository<PlanPosterImage, Long> {
+    
+    @Query("SELECT bi FROM PlanBannerImage bi WHERE bi.plan.id = :planId")
+    Optional<PlanBannerImage> findImagesByPlanId(@Param("planId") Long planId);
+    
+}

--- a/src/main/java/trend/project/repository/planRepository/LocationRepository.java
+++ b/src/main/java/trend/project/repository/planRepository/LocationRepository.java
@@ -1,0 +1,15 @@
+package trend.project.repository.planRepository;
+
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import trend.project.domain.Location;
+
+import java.util.Optional;
+
+public interface LocationRepository extends JpaRepository<Location, Long> {
+    
+    @Query("SELECT l FROM Location l WHERE l.plan.id = :planId")
+    Optional<Location> findByPlanId(Long planId);
+    
+}

--- a/src/main/java/trend/project/repository/planRepository/PlanRepository.java
+++ b/src/main/java/trend/project/repository/planRepository/PlanRepository.java
@@ -1,0 +1,14 @@
+package trend.project.repository.planRepository;
+
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import trend.project.domain.Plan;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PlanRepository extends JpaRepository<Plan, Long> {
+    
+    Optional<Plan> findById(Long id);
+
+}

--- a/src/main/java/trend/project/repository/planRepository/PosterImageRepository.java
+++ b/src/main/java/trend/project/repository/planRepository/PosterImageRepository.java
@@ -1,0 +1,15 @@
+package trend.project.repository.planRepository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import trend.project.domain.PlanPosterImage;
+
+import java.util.Optional;
+
+public interface PosterImageRepository extends JpaRepository<PlanPosterImage, Long> {
+    
+    @Query("SELECT pi FROM PlanPosterImage pi WHERE pi.plan.id = :planId")
+    Optional<PlanPosterImage> findImagesByPlanId(@Param("planId") Long planId);
+    
+}

--- a/src/main/java/trend/project/service/planService/PlanService.java
+++ b/src/main/java/trend/project/service/planService/PlanService.java
@@ -1,0 +1,12 @@
+package trend.project.service.planService;
+
+import org.springframework.stereotype.Service;
+import trend.project.web.dto.planDTO.PlanDetailDTO;
+
+import java.util.List;
+
+@Service
+public interface PlanService {
+    
+    PlanDetailDTO.PlanDetailResponseDTO getPlanDetail(Long planId);
+}

--- a/src/main/java/trend/project/service/planService/PlanServiceImpl.java
+++ b/src/main/java/trend/project/service/planService/PlanServiceImpl.java
@@ -1,0 +1,57 @@
+package trend.project.service.planService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import trend.project.api.code.status.ErrorStatus;
+import trend.project.api.exception.handler.PlanCategoryHandler;
+import trend.project.converter.PlanConverter;
+import trend.project.domain.*;
+import trend.project.repository.planRepository.BannerImageRepository;
+import trend.project.repository.planRepository.LocationRepository;
+import trend.project.repository.planRepository.PlanRepository;
+import trend.project.repository.planRepository.PosterImageRepository;
+import trend.project.web.dto.planDTO.PlanDetailDTO;
+
+@RequiredArgsConstructor
+@Transactional
+public class PlanServiceImpl implements PlanService {
+    
+    private final PlanRepository planRepository;
+    private final LocationRepository locationRepository;
+    private final PosterImageRepository posterImageRepository;
+    private final BannerImageRepository bannerImageRepository;
+    
+    @Override
+    public PlanDetailDTO.PlanDetailResponseDTO getPlanDetail(Long planId) {
+        
+        Plan findPlan = findPlanById(planId);
+        Member findMember = findPlan.getMember();
+        Location planLocation = getLocation(planId);
+        PlanPosterImage posterImage = getPosterImage(planId);
+        PlanBannerImage bannerImage = getBannerImage(planId);
+        
+        return PlanConverter.toPlanDetailResponseDTO(findPlan, findMember, planLocation, posterImage, bannerImage);
+    }
+    
+    private Location getLocation(Long planId) {
+        return locationRepository.findByPlanId(planId).orElseThrow(
+                () -> new PlanCategoryHandler(ErrorStatus.PLAN_LOCATION_NOT_FOUND)
+        );
+    }
+    
+    private PlanBannerImage getBannerImage(Long planId) {
+        return bannerImageRepository.findImagesByPlanId(planId).orElse(null);
+    }
+    
+    private PlanPosterImage getPosterImage(Long planId) {
+        return posterImageRepository.findImagesByPlanId(planId).orElseThrow(
+                () -> new PlanCategoryHandler(ErrorStatus.PLAN_POSTER_NOT_FOUND)
+        );
+    }
+    
+    private Plan findPlanById(Long planId) {
+        return planRepository.findById(planId).orElseThrow(
+                () -> new PlanCategoryHandler(ErrorStatus.PLAN_NOT_FOUND)
+        );
+    }
+}

--- a/src/main/java/trend/project/service/planService/PlanServiceImpl.java
+++ b/src/main/java/trend/project/service/planService/PlanServiceImpl.java
@@ -1,6 +1,7 @@
 package trend.project.service.planService;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import trend.project.api.code.status.ErrorStatus;
 import trend.project.api.exception.handler.PlanCategoryHandler;
@@ -12,6 +13,7 @@ import trend.project.repository.planRepository.PlanRepository;
 import trend.project.repository.planRepository.PosterImageRepository;
 import trend.project.web.dto.planDTO.PlanDetailDTO;
 
+@Service
 @RequiredArgsConstructor
 @Transactional
 public class PlanServiceImpl implements PlanService {

--- a/src/main/java/trend/project/web/controller/planController/PlanController.java
+++ b/src/main/java/trend/project/web/controller/planController/PlanController.java
@@ -1,0 +1,42 @@
+package trend.project.web.controller.planController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import trend.project.api.ApiResponse;
+import trend.project.service.planService.PlanService;
+import trend.project.web.dto.planDTO.PlanDetailDTO;
+
+@RestController
+@RequestMapping("/plans")
+@RequiredArgsConstructor
+@Tag(name = "기획서 API")
+public class PlanController {
+    
+    private final PlanService planService;
+    
+    @Operation(summary = "기획서 생성 API", description = "해당 API는 게시글의 정보를 입력받아 생성합니다.")
+    @PostMapping
+    public void createPlan() {
+    }
+    
+    @Operation(summary = "기획서 상세 조회 API", description = "해당 API는 게시글 상세 정보를 조회합니다.")
+    @GetMapping("/{planId}")
+    public ApiResponse<PlanDetailDTO.PlanDetailResponseDTO> getDetailPlan(@PathVariable Long planId) {
+        PlanDetailDTO.PlanDetailResponseDTO planDetail = planService.getPlanDetail(planId);
+        return ApiResponse.onSuccess(planDetail);
+    }
+    
+    @Operation(summary = "기획서 수정 API", description = "해당 API는 특정 게시글의 정보를 수정합니다. 권한는 작성자에게 있습니다.")
+    @PutMapping("/{id}")
+    public void updatePlan() {
+    }
+    
+    @Operation(summary = "기획서 삭제 API", description = "해당 API는 특정 게시글을 삭제합니다. 권한는 작성자에게 있습니다.")
+    @DeleteMapping("/{id}")
+    public void deletePlan() {
+    
+    }
+
+}

--- a/src/main/java/trend/project/web/dto/planDTO/PlanDTO.java
+++ b/src/main/java/trend/project/web/dto/planDTO/PlanDTO.java
@@ -1,0 +1,4 @@
+package trend.project.web.dto.planDTO;
+
+public class PlanDTO {
+}

--- a/src/main/java/trend/project/web/dto/planDTO/PlanDetailDTO.java
+++ b/src/main/java/trend/project/web/dto/planDTO/PlanDetailDTO.java
@@ -1,0 +1,74 @@
+package trend.project.web.dto.planDTO;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.time.LocalDate;
+
+public class PlanDetailDTO {
+    
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    @Getter
+    public static class PlanDetailResponseDTO {
+        
+        @Schema(description = "행사 제목 입니다")
+        private String title;
+        
+        @Schema(description = "행사 카테고리 입니다")
+        private String category;
+        
+        @Schema(description = "행사 시작 날짜 입니다")
+        private LocalDate startDate;
+        
+        @Schema(description = "행사 종료 날짜 입니다")
+        private LocalDate endDate;
+        
+        @Schema(description = "행사 대상 입니다")
+        private String target;
+        
+        @Schema(description = "행사 가격 입니다")
+        private int cost;
+        
+        @Schema(description = "행사 상세 설명 입니다")
+        private String content;
+        
+        @Schema(description = "행사 예산 입니다")
+        private int budget;
+        
+        @Schema(description = "게시글 좋아요 수 입니다")
+        private int likesCount;
+        
+        @Schema(description = "게시글 댓글 수 입니다")
+        private int commentCount;
+        
+        @Schema(description = "게시글 북마크 수 입니다")
+        private int bookmarkCount;
+        
+        @Schema(description = "행사 상태 입니다(대기 중, 진행중, 완료, 취소됨")
+        private String status;
+        
+        @Schema(description = "포스터 이미지 주소입니다.")
+        private String posterUrl;
+        
+        @Schema(description = "배너 이미지 주소입니다")
+        private String bannerUrl;
+        
+        @Schema(description = "기획자 이름입니다")
+        private String username;
+        
+        @Schema(description = "기획자 팔로워 수 입니다")
+        private int followerCount;
+        
+        /** 축제 개최 장소 **/
+        @Schema(description = "시/도")
+        private String province;
+        
+        @Schema(description = "시/군/구")
+        private String city;
+        
+        @Schema(description = "읍/면/동")
+        private String town;
+    }
+}


### PR DESCRIPTION
## Issue

- #17 


## Summary

- 기획서 상세 조회 API 구현

## Describe your code

- 게시글 화면에서 기획서의 정보를 상세하게 조회하는 API 구현

# Check
- [x] Reviewers 등록을 하였나요?
- [x] Assignees 등록을 하였나요?
- [x] 라벨 등록을 하였나요?
- [x] PR 머지하기 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced new error statuses for planning, enhancing error handling.
  - Added a new `PlanCategoryHandler` for managing plan-related exceptions.
  - Implemented `PlanConverter` for transforming plan data into a detailed response format.
  - New repositories for managing plan-related entities, including `BannerImageRepository`, `LocationRepository`, `PlanRepository`, and `PosterImageRepository`.
  - Added `PlanService` and its implementation for retrieving detailed plan information.
  - Created `PlanController` to handle HTTP requests related to plans, including endpoints for creating, retrieving, updating, and deleting plans.
  - Introduced `PlanDetailDTO` for comprehensive representation of plan details.

- **Bug Fixes**
  - Removed outdated error status `COMPANY_NOT_FOUND` to streamline error management.

- **Documentation**
  - Enhanced API documentation with detailed descriptions for new endpoints and data transfer objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->