### PR TITLE
[feat] S3 주입 및 회원&기업 프로필 이미지 CRUD 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,9 @@ dependencies {
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
+	// Spring Cloud Starter
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ dependencies {
 	// Spring Cloud Starter
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
+	implementation 'javax.xml.bind:jaxb-api:2.3.1'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/trend/project/api/code/status/ErrorStatus.java
+++ b/src/main/java/trend/project/api/code/status/ErrorStatus.java
@@ -11,7 +11,8 @@ import trend.project.api.code.ErrorReasonDTO;
 @Getter
 @AllArgsConstructor
 public enum ErrorStatus implements BaseErrorCode {
-    
+
+
     _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"COMMON1001","서버에러, 관리자에게 문의 바랍니다"),
     _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON1002","잘못된 요청입니다."),
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON1003","인증이 필요합니다."),
@@ -20,14 +21,22 @@ public enum ErrorStatus implements BaseErrorCode {
 
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER2001", "사용자가 없습니다."),
     MEMBER_USERNAME_DUPLICATE(HttpStatus.BAD_REQUEST,"MEMBER2002","중복된 ID 입니다"),
-    
-    //기획서 관련 오류
+
+
+    // 기획서 관련 오류
     PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAN4001", "기획서를 찾을 수 없습니다."),
     PLAN_POSTER_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAN4002", "포스터를 찾을 수 없습니다."),
     PLAN_BANNER_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAN4003", "배너를 찾을 수 없습니다."),
     PLAN_LOCATION_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAN4004", "주소를 찾을 수 없습니다."),
-    
-    
+
+
+    // 이미지 관련
+    IMAGE_CONVERT_FAIL(HttpStatus.MULTI_STATUS,"IMAGE5001","이미지 변환에 실패하였습니다"),
+    IMAGE_NOT_DELETED(HttpStatus.MULTI_STATUS,"IMAGE5002","이미지 삭제에 실패하였습니다"),
+    IMAGE_NOT_FOUND(HttpStatus.MULTI_STATUS,"IMAGE4003","이미지를 찾을 수 없습니다"),
+    IMAGE_NOT_ALLOWED(HttpStatus.MULTI_STATUS,"IMAGE5004","이미지를 다운받을 수 없습니다"),
+
+
     // 기업 관련 에러
     COMPANY_USERNAME_DUPLICATE(HttpStatus.MULTI_STATUS,"COMPANY4001","중복된 기업 username입니다"),
     COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, "COMPANY4002", "사용자가 없습니다."),

--- a/src/main/java/trend/project/api/exception/handler/ImageCategoryHandler.java
+++ b/src/main/java/trend/project/api/exception/handler/ImageCategoryHandler.java
@@ -1,0 +1,12 @@
+package trend.project.api.exception.handler;
+
+import trend.project.api.code.BaseErrorCode;
+import trend.project.api.exception.GeneralException;
+
+public class ImageCategoryHandler extends GeneralException {
+
+    public ImageCategoryHandler(BaseErrorCode baseErrorCode) {
+
+        super(baseErrorCode);
+    }
+}

--- a/src/main/java/trend/project/config/S3Config.java
+++ b/src/main/java/trend/project/config/S3Config.java
@@ -1,0 +1,32 @@
+package trend.project.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3Client() {
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return  AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .enablePathStyleAccess()
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+}

--- a/src/main/java/trend/project/domain/Company.java
+++ b/src/main/java/trend/project/domain/Company.java
@@ -59,6 +59,20 @@ public class Company {
 
 
 
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "agreement_id")
+    private Agreement agreement;
+
+    @OneToMany(mappedBy = "company",cascade = CascadeType.ALL)
+    private List<CompanyProfileImage> companyProfileImages = new ArrayList<>();
+
+    @OneToMany(mappedBy = "company",cascade = CascadeType.ALL)
+    private List<Address> addresses = new ArrayList<>();
+
+
+
+
+
     /* 연관관계 메서드 */
 
     // status를 INACTIVE로 변경하는 메서드
@@ -67,6 +81,11 @@ public class Company {
         this.status = Status.INACTIVE;
         this.inactiveDate = LocalDateTime.now();  // 비활성화 날짜 기록
 
+    }
+
+
+    public void setPassword(String password) {
+        this.password = password;
     }
 
 }

--- a/src/main/java/trend/project/domain/Member.java
+++ b/src/main/java/trend/project/domain/Member.java
@@ -6,6 +6,8 @@ import trend.project.domain.enumClass.Role;
 import trend.project.domain.enumClass.Status;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Builder
@@ -56,5 +58,38 @@ public class Member {
     @Column(nullable = false)
     private Integer FollowerCount = 0;
 
+
+
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<Address> address=new ArrayList<>();
+
+    @OneToMany(mappedBy = "member",cascade = CascadeType.ALL)
+    private List<MemberFollow> memberFollows=new ArrayList<>();
+
+    @OneToMany(mappedBy = "member",cascade = CascadeType.ALL)
+    private List<MemberFollower> memberFollowers=new ArrayList<>();
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "agreement_id")
+    private Agreement agreement;
+
+    @OneToMany(mappedBy = "member",cascade = CascadeType.ALL)
+    private List<MemberProfileImage> memberProfileImages=new ArrayList<>();
+
+
+
+    /* 연관관계 메서드 */
+
+    // status를 INACTIVE로 변경하는 메서드
+    public void setInactive() {
+
+        this.status = Status.INACTIVE;
+        this.inactiveDate = LocalDateTime.now();  // 비활성화 날짜 기록
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
 
 }

--- a/src/main/java/trend/project/repository/CompanyProfileImageRepository.java
+++ b/src/main/java/trend/project/repository/CompanyProfileImageRepository.java
@@ -1,0 +1,8 @@
+package trend.project.repository;
+
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import trend.project.domain.CompanyProfileImage;
+
+public interface CompanyProfileImageRepository extends JpaRepository<CompanyProfileImage, Long> {
+}

--- a/src/main/java/trend/project/repository/MemberProfileImageRepository.java
+++ b/src/main/java/trend/project/repository/MemberProfileImageRepository.java
@@ -1,0 +1,8 @@
+package trend.project.repository;
+
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import trend.project.domain.MemberProfileImage;
+
+public interface MemberProfileImageRepository extends JpaRepository<MemberProfileImage, Long> {
+}

--- a/src/main/java/trend/project/service/companyService/CompanyProfileImageService.java
+++ b/src/main/java/trend/project/service/companyService/CompanyProfileImageService.java
@@ -1,0 +1,33 @@
+package trend.project.service.companyService;
+
+
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import trend.project.domain.Company;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+public interface CompanyProfileImageService {
+    String upload(MultipartFile multipartFile, String dirName, String username) throws IOException;
+
+    File convert(MultipartFile file) throws IOException;
+
+    String putS3(File uploadFile, String fileName);
+
+    void removeNewFile(File targetFile);
+
+    void saveFileMetadata(String originalFileName, String uniqueFileName, long fileSize, String contentType,
+                          Company findCompany);
+
+    byte[] download(String username) throws IOException;
+
+    //companyId로 조회
+    byte[] downloadImage(Long companyId) throws IOException;
+
+    @Transactional
+    void deleteFile(String username) throws FileNotFoundException;
+
+    String updateProfileImage(MultipartFile newImageFile, String dirName, String username) throws IOException;
+}

--- a/src/main/java/trend/project/service/companyService/CompanyProfileImageServiceImpl.java
+++ b/src/main/java/trend/project/service/companyService/CompanyProfileImageServiceImpl.java
@@ -1,0 +1,288 @@
+package trend.project.service.companyService;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.*;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import trend.project.api.code.status.ErrorStatus;
+import trend.project.api.exception.handler.CompanyCategoryHandler;
+import trend.project.api.exception.handler.ImageCategoryHandler;
+import trend.project.domain.Company;
+import trend.project.domain.CompanyProfileImage;
+import trend.project.repository.CompanyProfileImageRepository;
+import trend.project.repository.CompanyRepository;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+@Slf4j
+@Transactional
+@RequiredArgsConstructor
+public class CompanyProfileImageServiceImpl implements CompanyProfileImageService {
+
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+    private final CompanyRepository companyRepository;
+    private final CompanyProfileImageRepository companyProfileImageRepository;
+
+
+
+    @Override
+    public String upload(MultipartFile multipartFile, String dirName, String username) throws IOException {
+
+        Company companyByUsername = getCompanyByUsername(username);
+
+        String originalFileName = multipartFile.getOriginalFilename();
+        String uuid = UUID.randomUUID().toString();
+        String uniqueFileName = uuid + "_" + originalFileName.replaceAll("\\s", "_");
+        String fileName = dirName + "/" + uniqueFileName;
+        File uploadFile = convert(multipartFile);
+
+        String uploadImageUrl = putS3(uploadFile, fileName);
+        removeNewFile(uploadFile);
+
+        // Save metadata to the database
+        saveFileMetadata(originalFileName, fileName, multipartFile.getSize(), multipartFile.getContentType(),companyByUsername);
+
+        return uploadImageUrl;
+    }
+
+
+
+    @Override
+    public File convert(MultipartFile file) throws IOException {
+        String originalFileName = file.getOriginalFilename();
+        String uuid = UUID.randomUUID().toString();
+        String uniqueFileName = uuid + "_" + originalFileName.replaceAll("\\s", "_");
+
+        File convertFile = new File(uniqueFileName);
+        if (convertFile.createNewFile()) {
+            try (FileOutputStream fos = new FileOutputStream(convertFile)) {
+                fos.write(file.getBytes());
+            } catch (IOException e) {
+                log.error("파일 변환 중 오류 발생: {}", e.getMessage());
+                throw new ImageCategoryHandler(ErrorStatus.IMAGE_CONVERT_FAIL);
+            }
+            return convertFile;
+        }
+        throw new ImageCategoryHandler(ErrorStatus.IMAGE_CONVERT_FAIL);
+    }
+
+
+    @Override
+    public String putS3(File uploadFile, String fileName) {
+        amazonS3.putObject(new PutObjectRequest(bucket, fileName, uploadFile)
+                .withCannedAcl(CannedAccessControlList.PublicRead));
+        return amazonS3.getUrl(bucket, fileName).toString();
+    }
+
+
+    @Override
+    public void removeNewFile(File targetFile) {
+        if (targetFile.delete()) {
+            log.info("파일이 삭제되었습니다.");
+        } else {
+            log.info("파일이 삭제되지 못했습니다.");
+            throw new ImageCategoryHandler(ErrorStatus.IMAGE_NOT_DELETED);
+        }
+    }
+
+
+    @Override
+    public void saveFileMetadata(String originalFileName, String uniqueFileName, long fileSize, String contentType,
+                                 Company findCompany) {
+
+        String name = findCompany.getName();
+
+
+        CompanyProfileImage image = CompanyProfileImage.builder()
+                .imageLink(uniqueFileName)
+                .imageName(originalFileName)
+                .company(findCompany)
+                .build();
+
+        companyProfileImageRepository.save(image);
+    }
+
+
+    @Override
+    public byte[] download(String username) throws IOException {
+
+
+        Company companyByUsername = getCompanyByUsername(username);
+
+        CompanyProfileImage findCompanyProfileImage = companyByUsername.getCompanyProfileImages().stream()
+                .findFirst()
+                .orElseThrow(()->new ImageCategoryHandler(ErrorStatus.IMAGE_NOT_FOUND));
+
+
+        CompanyProfileImage image = companyProfileImageRepository.findById(findCompanyProfileImage.getId())
+                .orElseThrow(()->new ImageCategoryHandler(ErrorStatus.IMAGE_NOT_FOUND));
+
+
+        String uniqueFileName = image.getImageLink();  // Use full path as S3 key
+        log.info("Downloading file from S3 with key: {}", uniqueFileName);
+
+        try {
+            S3Object s3Object = amazonS3.getObject(new GetObjectRequest(bucket, uniqueFileName));
+            try (S3ObjectInputStream inputStream = s3Object.getObjectContent()) {
+                return inputStream.readAllBytes();
+            }
+        } catch (AmazonS3Exception e) {
+            log.error("S3에서 파일 다운로드 오류: {}", e.getMessage());
+            throw new ImageCategoryHandler(ErrorStatus.IMAGE_NOT_ALLOWED);
+        }
+    }
+
+
+
+
+
+
+    //companyId로 조회
+    @Override
+    public byte[] downloadImage(Long companyId) throws IOException {
+
+
+        Company companyByUsername = getCompanyById(companyId);
+
+        CompanyProfileImage findCompanyProfileImage = companyByUsername.getCompanyProfileImages().stream()
+                .findFirst()
+                .orElseThrow(()->new ImageCategoryHandler(ErrorStatus.IMAGE_NOT_FOUND));
+
+
+        CompanyProfileImage image = companyProfileImageRepository.findById(findCompanyProfileImage.getId())
+                .orElseThrow(()->new ImageCategoryHandler(ErrorStatus.IMAGE_NOT_FOUND));
+
+
+        String uniqueFileName = image.getImageLink();  // Use full path as S3 key
+        log.info("Downloading file from S3 with key: {}", uniqueFileName);
+
+        try {
+            S3Object s3Object = amazonS3.getObject(new GetObjectRequest(bucket, uniqueFileName));
+            try (S3ObjectInputStream inputStream = s3Object.getObjectContent()) {
+                return inputStream.readAllBytes();
+            }
+        } catch (AmazonS3Exception e) {
+            log.error("S3에서 파일 다운로드 오류: {}", e.getMessage());
+            throw new ImageCategoryHandler(ErrorStatus.IMAGE_NOT_ALLOWED);
+        }
+    }
+
+
+
+
+
+    @Transactional
+    @Override
+    public void deleteFile(String username) throws FileNotFoundException {
+        try {
+            // 유저 찾기
+            Company companyByUsername = getCompanyByUsername(username);
+
+            // 첫 번째 프로필 이미지 찾기
+            CompanyProfileImage findCompanyProfileImage = companyByUsername.getCompanyProfileImages().stream()
+                    .findFirst()
+                    .orElseThrow(()->new ImageCategoryHandler(ErrorStatus.IMAGE_NOT_FOUND));
+
+            // 이미지 ID로 조회
+            Long companyProfileImageId = findCompanyProfileImage.getId();
+            CompanyProfileImage image = companyProfileImageRepository.findById(companyProfileImageId)
+                    .orElseThrow(()->new ImageCategoryHandler(ErrorStatus.IMAGE_NOT_FOUND));
+
+            // 파일 경로(S3 키)
+            String uniqueFileName = image.getImageLink();
+            if (uniqueFileName != null) {
+                // AWS S3에서 파일 삭제
+                amazonS3.deleteObject(bucket, uniqueFileName);
+
+                companyByUsername.getCompanyProfileImages().remove(image);
+                image.setCompany(null);
+
+                log.info("Attempting to delete UserProfileImage with ID: {}", companyProfileImageId);
+
+                // 로컬 DB에서 엔티티 삭제
+                companyProfileImageRepository.deleteById(companyProfileImageId);
+
+                // 명시적으로 flush 호출
+                entityManager.flush();
+                // 1차 캐시 클리어
+                entityManager.clear();
+                log.info("Successfully deleted UserProfileImage with ID: {}", companyProfileImageId);
+            } else {
+                log.error("파일을 찾을 수 없습니다: ID {}", companyProfileImageId);
+            }
+
+        } catch (Exception e) {
+            log.error("파일 삭제 중 오류가 발생했습니다: ", e);
+            throw new ImageCategoryHandler(ErrorStatus.IMAGE_NOT_DELETED);
+        }
+    }
+
+
+    @Override
+    public String updateProfileImage(MultipartFile newImageFile, String dirName, String username) throws IOException {
+        // 유저 찾기
+        Company companyByUsername = getCompanyByUsername(username);
+
+        // 기존 프로필 이미지 삭제
+        deleteFile(username);
+
+        // 새로운 이미지 업로드
+        String originalFileName = newImageFile.getOriginalFilename();
+        String uuid = UUID.randomUUID().toString();
+        String uniqueFileName = uuid + "_" + originalFileName.replaceAll("\\s", "_");
+        String fileName = dirName + "/" + uniqueFileName;
+        File uploadFile = convert(newImageFile);
+
+        String uploadImageUrl = putS3(uploadFile, fileName);
+        removeNewFile(uploadFile);
+
+        // 새로운 메타데이터 저장
+        saveFileMetadata(originalFileName, fileName, newImageFile.getSize(), newImageFile.getContentType(), companyByUsername);
+
+        return uploadImageUrl;
+    }
+
+
+
+
+
+
+
+
+
+
+
+    // 회원 찾는 메서드
+    public Company getCompanyById(Long companyId){
+        return companyRepository.findById(companyId)
+                .orElseThrow(()-> new CompanyCategoryHandler(ErrorStatus.COMPANY_NOT_FOUND));
+    }
+
+
+
+
+    // 회원 찾는 메서드
+    public Company getCompanyByUsername(String username){
+        return companyRepository.findByUsername(username)
+                .orElseThrow(()-> new CompanyCategoryHandler(ErrorStatus.COMPANY_NOT_FOUND));
+    }
+}

--- a/src/main/java/trend/project/service/memberService/MemberProfileImageService.java
+++ b/src/main/java/trend/project/service/memberService/MemberProfileImageService.java
@@ -1,0 +1,35 @@
+package trend.project.service.memberService;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+@Service
+public interface MemberProfileImageService {
+
+
+    String upload(MultipartFile multipartFile, String dirName, String username) throws IOException;
+
+    File convert(MultipartFile file) throws IOException;
+
+    String putS3(File uploadFile, String fileName);
+
+    void removeNewFile(File targetFile);
+
+    void saveFileMetadata(String originalFileName, String uniqueFileName, long fileSize, String contentType,
+                          Member findMember);
+
+    byte[] download(String username) throws IOException;
+
+    // memberId로 이미지 조회
+    byte[] downloadImage(Long memberId) throws IOException;
+
+    @Transactional
+    void deleteFile(String username) throws FileNotFoundException;
+
+    String updateProfileImage(MultipartFile newImageFile, String dirName, String username) throws IOException;
+}

--- a/src/main/java/trend/project/service/memberService/MemberProfileImageService.java
+++ b/src/main/java/trend/project/service/memberService/MemberProfileImageService.java
@@ -3,6 +3,7 @@ package trend.project.service.memberService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import trend.project.domain.Member;
 
 import java.io.File;
 import java.io.FileNotFoundException;

--- a/src/main/java/trend/project/service/memberService/MemberProfileImageServiceImpl.java
+++ b/src/main/java/trend/project/service/memberService/MemberProfileImageServiceImpl.java
@@ -1,0 +1,281 @@
+package trend.project.service.memberService;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.*;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+@Slf4j
+@Transactional
+@RequiredArgsConstructor
+public class MemberProfileImageServiceImpl implements MemberProfileImageService {
+
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+    private final MemberRepository memberRepository;
+    private final MemberProfileImageRepository memberProfileImageRepository;
+
+
+
+    @Override
+    public String upload(MultipartFile multipartFile, String dirName, String username) throws IOException {
+
+        Member memberByUsername = getMemberByUsername(username);
+
+        String originalFileName = multipartFile.getOriginalFilename();
+        String uuid = UUID.randomUUID().toString();
+        String uniqueFileName = uuid + "_" + originalFileName.replaceAll("\\s", "_");
+        String fileName = dirName + "/" + uniqueFileName;
+        File uploadFile = convert(multipartFile);
+
+        String uploadImageUrl = putS3(uploadFile, fileName);
+        removeNewFile(uploadFile);
+
+        // Save metadata to the database
+        saveFileMetadata(originalFileName, fileName, multipartFile.getSize(), multipartFile.getContentType(),memberByUsername);
+
+        return uploadImageUrl;
+    }
+
+
+
+    @Override
+    public File convert(MultipartFile file) throws IOException {
+        String originalFileName = file.getOriginalFilename();
+        String uuid = UUID.randomUUID().toString();
+        String uniqueFileName = uuid + "_" + originalFileName.replaceAll("\\s", "_");
+
+        File convertFile = new File(uniqueFileName);
+        if (convertFile.createNewFile()) {
+            try (FileOutputStream fos = new FileOutputStream(convertFile)) {
+                fos.write(file.getBytes());
+            } catch (IOException e) {
+                log.error("파일 변환 중 오류 발생: {}", e.getMessage());
+                throw new ImageCategoryHandler(ErrorStatus.IMAGE_CONVERT_FAIL);
+            }
+            return convertFile;
+        }
+        throw new ImageCategoryHandler(ErrorStatus.IMAGE_CONVERT_FAIL);
+    }
+
+
+    @Override
+    public String putS3(File uploadFile, String fileName) {
+        amazonS3.putObject(new PutObjectRequest(bucket, fileName, uploadFile)
+                .withCannedAcl(CannedAccessControlList.PublicRead));
+        return amazonS3.getUrl(bucket, fileName).toString();
+    }
+
+
+    @Override
+    public void removeNewFile(File targetFile) {
+        if (targetFile.delete()) {
+            log.info("파일이 삭제되었습니다.");
+        } else {
+            log.info("파일이 삭제되지 못했습니다.");
+            throw new ImageCategoryHandler(ErrorStatus.IMAGE_NOT_DELETED);
+        }
+    }
+
+
+    @Override
+    public void saveFileMetadata(String originalFileName, String uniqueFileName, long fileSize, String contentType,
+                                 Member findMember) {
+
+        String name = findMember.getName();
+
+
+        MemberProfileImage image = MemberProfileImage.builder()
+                .imageLink(uniqueFileName)
+                .imageName(originalFileName)
+                .member(findMember)
+                .build();
+
+        memberProfileImageRepository.save(image);
+    }
+
+
+    @Override
+    public byte[] download(String username) throws IOException {
+
+
+        Member memberByUsername = getMemberByUsername(username);
+
+        MemberProfileImage findMemberProfileImage = memberByUsername.getMemberProfileImages().stream()
+                .findFirst()
+                .orElseThrow(()->new ImageCategoryHandler(ErrorStatus.IMAGE_NOT_FOUND));
+
+
+        MemberProfileImage image = memberProfileImageRepository.findById(findMemberProfileImage.getId())
+                .orElseThrow(()->new ImageCategoryHandler(ErrorStatus.IMAGE_NOT_FOUND));
+
+
+        String uniqueFileName = image.getImageLink();  // Use full path as S3 key
+        log.info("Downloading file from S3 with key: {}", uniqueFileName);
+
+        try {
+            S3Object s3Object = amazonS3.getObject(new GetObjectRequest(bucket, uniqueFileName));
+            try (S3ObjectInputStream inputStream = s3Object.getObjectContent()) {
+                return inputStream.readAllBytes();
+            }
+        } catch (AmazonS3Exception e) {
+            log.error("S3에서 파일 다운로드 오류: {}", e.getMessage());
+            throw new ImageCategoryHandler(ErrorStatus.IMAGE_NOT_ALLOWED);
+        }
+    }
+
+
+
+    // memberId로 이미지 조회
+    @Override
+    public byte[] downloadImage(Long memberId) throws IOException {
+
+
+        Member memberById = getMemberById(memberId);
+
+        MemberProfileImage findMemberProfileImage = memberById.getMemberProfileImages().stream()
+                .findFirst()
+                .orElseThrow(()->new ImageCategoryHandler(ErrorStatus.IMAGE_NOT_FOUND));
+
+
+        MemberProfileImage image = memberProfileImageRepository.findById(findMemberProfileImage.getId())
+                .orElseThrow(()->new ImageCategoryHandler(ErrorStatus.IMAGE_NOT_FOUND));
+
+
+        String uniqueFileName = image.getImageLink();  // Use full path as S3 key
+        log.info("Downloading file from S3 with key: {}", uniqueFileName);
+
+        try {
+            S3Object s3Object = amazonS3.getObject(new GetObjectRequest(bucket, uniqueFileName));
+            try (S3ObjectInputStream inputStream = s3Object.getObjectContent()) {
+                return inputStream.readAllBytes();
+            }
+        } catch (AmazonS3Exception e) {
+            log.error("S3에서 파일 다운로드 오류: {}", e.getMessage());
+            throw new ImageCategoryHandler(ErrorStatus.IMAGE_NOT_ALLOWED);
+        }
+    }
+
+
+
+
+
+
+    @Transactional
+    @Override
+    public void deleteFile(String username) throws FileNotFoundException {
+        try {
+            // 유저 찾기
+            Member memberByUsername = getMemberByUsername(username);
+
+            // 첫 번째 프로필 이미지 찾기
+            MemberProfileImage findMemberProfileImage = memberByUsername.getMemberProfileImages().stream()
+                    .findFirst()
+                    .orElseThrow(()->new ImageCategoryHandler(ErrorStatus.IMAGE_NOT_FOUND));
+
+            // 이미지 ID로 조회
+            Long memberProfileImageId = findMemberProfileImage.getId();
+            MemberProfileImage image = memberProfileImageRepository.findById(memberProfileImageId)
+                    .orElseThrow(()->new ImageCategoryHandler(ErrorStatus.IMAGE_NOT_FOUND));
+
+            // 파일 경로(S3 키)
+            String uniqueFileName = image.getImageLink();
+            if (uniqueFileName != null) {
+                // AWS S3에서 파일 삭제
+                amazonS3.deleteObject(bucket, uniqueFileName);
+
+                memberByUsername.getMemberProfileImages().remove(image);
+                image.setMember(null);
+
+                log.info("Attempting to delete UserProfileImage with ID: {}", memberProfileImageId);
+
+                // 로컬 DB에서 엔티티 삭제
+                memberProfileImageRepository.deleteById(memberProfileImageId);
+
+                // 명시적으로 flush 호출
+                entityManager.flush();
+                // 1차 캐시 클리어
+                entityManager.clear();
+                log.info("Successfully deleted UserProfileImage with ID: {}", memberProfileImageId);
+            } else {
+                log.error("파일을 찾을 수 없습니다: ID {}", memberProfileImageId);
+            }
+
+        } catch (Exception e) {
+            log.error("파일 삭제 중 오류가 발생했습니다: ", e);
+            throw new ImageCategoryHandler(ErrorStatus.IMAGE_NOT_DELETED);
+        }
+    }
+
+
+    @Override
+    public String updateProfileImage(MultipartFile newImageFile, String dirName, String username) throws IOException {
+        // 유저 찾기
+        Member memberByUsername = getMemberByUsername(username);
+
+        // 기존 프로필 이미지 삭제
+        deleteFile(username);
+
+        // 새로운 이미지 업로드
+        String originalFileName = newImageFile.getOriginalFilename();
+        String uuid = UUID.randomUUID().toString();
+        String uniqueFileName = uuid + "_" + originalFileName.replaceAll("\\s", "_");
+        String fileName = dirName + "/" + uniqueFileName;
+        File uploadFile = convert(newImageFile);
+
+        String uploadImageUrl = putS3(uploadFile, fileName);
+        removeNewFile(uploadFile);
+
+        // 새로운 메타데이터 저장
+        saveFileMetadata(originalFileName, fileName, newImageFile.getSize(), newImageFile.getContentType(), memberByUsername);
+
+        return uploadImageUrl;
+    }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    // 회원 찾는 메서드
+    public Member getMemberByUsername(String username){
+        return memberRepository.findByUsername(username)
+                .orElseThrow(()-> new MemberCategoryHandler(ErrorStatus.MEMBER_NOT_FOUND));
+    }
+
+
+    // 회원 찾는 메서드
+    public Member getMemberById(Long memberId){
+        return memberRepository.findById(memberId)
+                .orElseThrow(()-> new MemberCategoryHandler(ErrorStatus.MEMBER_NOT_FOUND));
+    }
+}

--- a/src/main/java/trend/project/service/memberService/MemberProfileImageServiceImpl.java
+++ b/src/main/java/trend/project/service/memberService/MemberProfileImageServiceImpl.java
@@ -10,6 +10,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import trend.project.api.code.status.ErrorStatus;
+import trend.project.api.exception.handler.MemberCategoryHandler;
 import trend.project.domain.Member;
 import trend.project.domain.MemberProfileImage;
 import trend.project.repository.MemberProfileImageRepository;

--- a/src/main/java/trend/project/service/memberService/MemberProfileImageServiceImpl.java
+++ b/src/main/java/trend/project/service/memberService/MemberProfileImageServiceImpl.java
@@ -10,6 +10,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import trend.project.domain.Member;
+import trend.project.domain.MemberProfileImage;
+import trend.project.repository.MemberProfileImageRepository;
+import trend.project.repository.MemberRepository;
 
 import java.io.File;
 import java.io.FileNotFoundException;

--- a/src/main/java/trend/project/service/memberService/MemberProfileImageServiceImpl.java
+++ b/src/main/java/trend/project/service/memberService/MemberProfileImageServiceImpl.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import trend.project.api.code.status.ErrorStatus;
+import trend.project.api.exception.handler.ImageCategoryHandler;
 import trend.project.api.exception.handler.MemberCategoryHandler;
 import trend.project.domain.Member;
 import trend.project.domain.MemberProfileImage;

--- a/src/main/java/trend/project/web/controller/CompanyImageController.java
+++ b/src/main/java/trend/project/web/controller/CompanyImageController.java
@@ -1,0 +1,162 @@
+package trend.project.web.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import trend.project.api.ApiResponse;
+import trend.project.service.companyService.CompanyProfileImageService;
+
+import java.io.IOException;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/companies/images")
+@Slf4j
+@Tag(name = "기업 프로필 이미지 관리 API")
+public class CompanyImageController {
+
+    private final CompanyProfileImageService companyProfileImageService;
+
+
+
+
+
+    @Operation(summary = "프로필 사진 등록 API")
+    @PostMapping(path = "", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<String> uploadCompanyProfileImage(
+            @RequestPart(value = "file") MultipartFile multipartFile,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) throws IOException {
+
+        String username = userDetails.getUsername();
+
+        String dirName="기업 프로필 이미지";
+        String url = companyProfileImageService.upload(multipartFile, dirName, username);
+        log.info("파일 업로드 완료: {}", url);
+
+        return ApiResponse.onSuccess(url);
+    }
+
+
+
+
+
+
+    @Operation(summary = "본인 프로필 사진 조회 API")
+    @GetMapping(path = "")
+    public ResponseEntity<byte[]> getCompanyProfileImage(
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        String username = userDetails.getUsername();
+
+        try {
+            byte[] fileData = companyProfileImageService.download(username);
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_OCTET_STREAM);
+            headers.setContentDispositionFormData("attachment", "filename");
+            log.info("파일 다운로드 완료: ID {}", username);
+
+            return new ResponseEntity<>(fileData, headers, HttpStatus.OK);
+        } catch (Exception e) {
+
+            log.error("파일 다운로드 오류: {}", e.getMessage());
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+    }
+
+
+
+    @Operation(summary = "프로필 사진 조회 API")
+    @GetMapping(path = "/{companyId}")
+    public ResponseEntity<byte[]> getProfileImage(
+            @PathVariable Long companyId) {
+
+
+        try {
+            byte[] fileData = companyProfileImageService.downloadImage(companyId);
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_OCTET_STREAM);
+            headers.setContentDispositionFormData("attachment", "filename");
+            log.info("파일 다운로드 완료: ID {}", companyId);
+
+            return new ResponseEntity<>(fileData, headers, HttpStatus.OK);
+        } catch (Exception e) {
+
+            log.error("파일 다운로드 오류: {}", e.getMessage());
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+    }
+
+
+
+
+
+
+
+    @Operation(summary = "프로필 사진 삭제 API")
+    @DeleteMapping(path = "")
+    public ApiResponse<String> deleteCompanyProfileImage(
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+
+        String username = userDetails.getUsername();
+
+
+        try {
+
+            companyProfileImageService.deleteFile(username);
+
+            return ApiResponse.onSuccess("삭제에 성공하였습니다");
+
+        } catch (Exception e) {
+            log.error("파일 삭제 오류: {}", e.getMessage());
+            return ApiResponse.onFailure("404","이미지를 찾을 수 없습니다",null);
+        }
+    }
+
+
+
+
+
+
+    @Operation(summary = "프로필 사진 업데이트 API")
+    @PutMapping(path = "", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<String> updateCompanyProfileImage(
+            @RequestPart(value = "file") MultipartFile multipartFile,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) throws IOException {
+
+
+        String username = userDetails.getUsername();
+        String dirName = "기업 프로필 이미지";
+
+
+        try {
+
+            String url = companyProfileImageService.updateProfileImage(multipartFile, dirName, username);
+            log.info("프로필 이미지 업데이트 완료: {}", url);
+
+            return ApiResponse.onSuccess(url);
+
+        } catch (Exception e) {
+
+            log.error("프로필 이미지 업데이트 오류: {}", e.getMessage());
+
+            return ApiResponse.onFailure("404","이미지를 찾을 수 없습니다",null);
+        }
+    }
+
+
+
+}

--- a/src/main/java/trend/project/web/controller/MemberImageController.java
+++ b/src/main/java/trend/project/web/controller/MemberImageController.java
@@ -1,0 +1,162 @@
+package trend.project.web.controller;
+
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import trend.project.api.ApiResponse;
+import trend.project.service.memberService.MemberProfileImageService;
+
+import java.io.IOException;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/members/images")
+@Slf4j
+@Tag(name = "개인 프로필 이미지 관리 API")
+public class MemberImageController {
+
+
+    private final MemberProfileImageService memberProfileImageService;
+
+
+
+
+    @Operation(summary = "프로필 사진 등록 API")
+    @PostMapping(path = "", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<String> uploadMemberProfileImage(
+            @RequestPart(value = "file") MultipartFile multipartFile,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) throws IOException {
+
+        String username = userDetails.getUsername();
+
+        String dirName="회원 프로필 이미지";
+        String url = memberProfileImageService.upload(multipartFile, dirName, username);
+        log.info("파일 업로드 완료: {}", url);
+
+        return ApiResponse.onSuccess(url);
+    }
+
+
+
+
+
+    @Operation(summary = "본인 프로필 사진 조회 API")
+    @GetMapping(path = "")
+    public ResponseEntity<byte[]> getMemberProfileImage(
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        String username = userDetails.getUsername();
+
+        try {
+            byte[] fileData = memberProfileImageService.download(username);
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_OCTET_STREAM);
+            headers.setContentDispositionFormData("attachment", "filename");
+            log.info("파일 다운로드 완료: ID {}", username);
+
+            return new ResponseEntity<>(fileData, headers, HttpStatus.OK);
+        } catch (Exception e) {
+
+            log.error("파일 다운로드 오류: {}", e.getMessage());
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+    }
+
+
+
+
+    @Operation(summary = "프로필 사진 조회 API")
+    @GetMapping(path = "/{memberId}")
+    public ResponseEntity<byte[]> getProfileImage(
+            @PathVariable Long memberId) {
+
+
+        try {
+            byte[] fileData = memberProfileImageService.downloadImage(memberId);
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_OCTET_STREAM);
+            headers.setContentDispositionFormData("attachment", "filename");
+            log.info("파일 다운로드 완료: ID {}", memberId);
+
+            return new ResponseEntity<>(fileData, headers, HttpStatus.OK);
+        } catch (Exception e) {
+
+            log.error("파일 다운로드 오류: {}", e.getMessage());
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+    }
+
+
+
+
+
+
+    @Operation(summary = "프로필 사진 삭제 API")
+    @DeleteMapping(path = "")
+    public ApiResponse<String> deleteMemberProfileImage(
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+
+        String username = userDetails.getUsername();
+
+
+        try {
+
+            memberProfileImageService.deleteFile(username);
+
+            return ApiResponse.onSuccess("삭제에 성공하였습니다");
+
+        } catch (Exception e) {
+            log.error("파일 삭제 오류: {}", e.getMessage());
+            return ApiResponse.onFailure("404","이미지를 찾을 수 없습니다",null);
+        }
+    }
+
+
+
+
+
+
+    @Operation(summary = "프로필 사진 업데이트 API")
+    @PutMapping(path = "", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<String> updateMemberProfileImage(
+            @RequestPart(value = "file") MultipartFile multipartFile,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) throws IOException {
+
+
+        String username = userDetails.getUsername();
+        String dirName = "회원 프로필 이미지";
+
+
+        try {
+
+            String url = memberProfileImageService.updateProfileImage(multipartFile, dirName, username);
+            log.info("프로필 이미지 업데이트 완료: {}", url);
+
+            return ApiResponse.onSuccess(url);
+
+        } catch (Exception e) {
+
+            log.error("프로필 이미지 업데이트 오류: {}", e.getMessage());
+
+            return ApiResponse.onFailure("404","이미지를 찾을 수 없습니다",null);
+        }
+    }
+
+
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,3 +30,18 @@ spring:
 
 springdoc:
   show-login-endpoint: true
+
+
+
+cloud:
+  aws:
+    s3:
+      bucket: trends-buckets
+    credentials:
+      accessKey: ${S3_ACCESSKEY}
+      secretKey: ${S3_SECRETS}
+    region:
+      static: ap-northeast-2
+      auto: false
+    stack:
+      auto: false


### PR DESCRIPTION
## Issue

- #20 


## Summary

- S3 주입 및 회원&기업 프로필 이미지 CRUD 구현

## Describe your code

- S3 주입 및 회원&기업 프로필 이미지 CRUD 구현

# Check
- [ ] Reviewers 등록을 하였나요?
- [ ] Assignees 등록을 하였나요?
- [ ] 라벨 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced RESTful APIs for managing company and member profile images, including upload, retrieval, update, and deletion functionalities.
	- Added support for AWS S3 integration for image storage and retrieval.
	- New error statuses related to image processing have been implemented.

- **Enhancements**
	- Improved data models for `Company` and `Member` with new relationships and methods for managing profile images and agreements.
	- Enhanced configuration for AWS S3 settings in the application.

- **Bug Fixes**
	- Updated error handling for image-related operations to provide clearer feedback.

These updates enhance the overall functionality and user experience related to profile image management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->