### PR TITLE
[feat] 게시글 관련 댓글 조회 API 구현

### DIFF
--- a/src/main/java/trend/project/config/SecurityConfig.java
+++ b/src/main/java/trend/project/config/SecurityConfig.java
@@ -89,6 +89,7 @@ public class SecurityConfig {
                 .requestMatchers("members/join","/login","/companies/join").permitAll()
                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/webjars/**").permitAll()// Swagger 관련 경로를 허용
                 .requestMatchers(HttpMethod.GET, "/plans/{id}").permitAll()
+                .requestMatchers(HttpMethod.GET, "/comments/{id}").permitAll()
                 
                 
                 .anyRequest().authenticated());

--- a/src/main/java/trend/project/converter/CommentConverter.java
+++ b/src/main/java/trend/project/converter/CommentConverter.java
@@ -1,0 +1,24 @@
+package trend.project.converter;
+
+import trend.project.domain.Comment;
+import trend.project.web.dto.commentDTO.CommentDTO;
+
+public class CommentConverter {
+    public static CommentDTO.CommentResponseDTO toCommentResponseDTO(Comment comment) {
+        return CommentDTO.CommentResponseDTO.builder()
+                .id(comment.getId())
+                .body(comment.getBody())
+                .likesCount(comment.getLikesCount())
+                .haveParentComment(comment.getHaveParentComment())
+                .parentCommentId(comment.getParentComment() != null ? comment.getParentComment().getId() : null)
+                .depth(comment.getDepth())
+                .orderNumber(comment.getOrderNumber())
+                .type(String.valueOf(comment.getType()))
+                .memberName(comment.getMember() != null ? comment.getMember().getUsername() : null)
+                .companyName(comment.getCompany() != null ? comment.getCompany().getUsername() : null)
+                .updatedAt(comment.getUpdatedAt())
+                .deletedAt(comment.getDeletedAt())
+                .deletedTrue(comment.isDeletedTrue())
+                .build();
+    }
+}

--- a/src/main/java/trend/project/repository/CommentRepository.java
+++ b/src/main/java/trend/project/repository/CommentRepository.java
@@ -1,0 +1,12 @@
+package trend.project.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import trend.project.domain.Comment;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    
+    Optional<List<Comment>> findByPlanId(Long planId);
+}

--- a/src/main/java/trend/project/service/commentService/CommentService.java
+++ b/src/main/java/trend/project/service/commentService/CommentService.java
@@ -1,0 +1,15 @@
+package trend.project.service.commentService;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import trend.project.web.dto.commentDTO.CommentDTO;
+
+import java.util.List;
+
+@Service
+@Transactional
+public interface CommentService {
+    
+    List<CommentDTO.CommentResponseDTO> getComments(Long planId);
+    
+}

--- a/src/main/java/trend/project/service/commentService/CommentServiceImpl.java
+++ b/src/main/java/trend/project/service/commentService/CommentServiceImpl.java
@@ -1,0 +1,28 @@
+package trend.project.service.commentService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import trend.project.converter.CommentConverter;
+import trend.project.domain.Comment;
+import trend.project.repository.CommentRepository;
+import trend.project.web.dto.commentDTO.CommentDTO;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CommentServiceImpl implements CommentService{
+    
+    private final CommentRepository commentRepository;
+    
+    @Override
+    public List<CommentDTO.CommentResponseDTO> getComments(Long planId) {
+        List<Comment> comments = commentRepository.findByPlanId(planId).orElse(null);
+        return comments.stream()
+                .map(CommentConverter::toCommentResponseDTO)
+                .toList();
+    }
+    
+}

--- a/src/main/java/trend/project/web/controller/commentController/CommentController.java
+++ b/src/main/java/trend/project/web/controller/commentController/CommentController.java
@@ -1,0 +1,30 @@
+package trend.project.web.controller.commentController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import trend.project.api.ApiResponse;
+import trend.project.service.commentService.CommentService;
+import trend.project.web.dto.commentDTO.CommentDTO;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/comments")
+@RequiredArgsConstructor
+@Tag(name = "댓글 API")
+public class CommentController {
+    
+    private final CommentService commentService;
+    
+    @Operation(summary = "기획서 댓글 조회 API", description = "해당 API는 기획서에 달린 댓글들의 정보를 조회합니다.")
+    @GetMapping("/{planId}")
+    public ApiResponse<List<CommentDTO.CommentResponseDTO>> getComments(@PathVariable Long planId) {
+        List<CommentDTO.CommentResponseDTO> comments = commentService.getComments(planId);
+        return ApiResponse.onSuccess(comments);
+    }
+}

--- a/src/main/java/trend/project/web/dto/commentDTO/CommentDTO.java
+++ b/src/main/java/trend/project/web/dto/commentDTO/CommentDTO.java
@@ -1,0 +1,29 @@
+package trend.project.web.dto.commentDTO;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+public class CommentDTO {
+    
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    @Getter
+    public static class CommentResponseDTO {
+        
+        private Long id;
+        private String body;
+        private int likesCount;
+        private boolean haveParentComment;
+        private Long parentCommentId;
+        private int depth;
+        private int orderNumber;
+        private String  type;
+        private String memberName;
+        private String companyName;
+        private LocalDateTime updatedAt;
+        private LocalDateTime deletedAt;
+        private boolean deletedTrue;
+    }
+}


### PR DESCRIPTION
## Issue

- #22 


## Summary

- 댓글 조회 API 구현 PR

## Describe your code

- 게시글의 등록된 댓글들을 전부 조회합니다.

# Check
- [ ] Reviewers 등록을 하였나요?
- [ ] Assignees 등록을 하였나요?
- [ ] 라벨 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced security configuration allowing unauthenticated access to specific comment endpoints.
  - Introduced a new `CommentController` for managing comments via a REST API.
  - Added `CommentService` and `CommentServiceImpl` for handling comment retrieval.
  - New `CommentConverter` for converting comments to response DTOs.
  - Implemented `CommentRepository` for fetching comments by plan ID.
  - Created `CommentDTO` with a nested `CommentResponseDTO` for structured comment data.

- **Bug Fixes**
  - Improved error handling for null values in comment responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->