### PR TITLE
[feat] 기획서 생성 API 구현

### DIFF
--- a/src/main/java/trend/project/api/code/status/ErrorStatus.java
+++ b/src/main/java/trend/project/api/code/status/ErrorStatus.java
@@ -28,6 +28,8 @@ public enum ErrorStatus implements BaseErrorCode {
     PLAN_POSTER_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAN4002", "포스터를 찾을 수 없습니다."),
     PLAN_BANNER_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAN4003", "배너를 찾을 수 없습니다."),
     PLAN_LOCATION_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAN4004", "주소를 찾을 수 없습니다."),
+    CATEGORY_INVALID(HttpStatus.BAD_REQUEST, "PLAN4004", "일치하는 카테고리를 찾을 수 없습니다."),
+    PlAN_END_DATE_INVALID(HttpStatus.BAD_REQUEST, "PLAN4005", "종료일은 시작일 이후로 설정해 주세요."),
 
 
     // 이미지 관련

--- a/src/main/java/trend/project/converter/LocationConverter.java
+++ b/src/main/java/trend/project/converter/LocationConverter.java
@@ -1,0 +1,15 @@
+package trend.project.converter;
+
+import trend.project.domain.Location;
+import trend.project.web.dto.planDTO.PlanDTO;
+
+public class LocationConverter {
+    
+    public static Location toPlanLocation(PlanDTO.PlanCreateRequestDTO planCreateRequestDTO) {
+        return Location.builder()
+                .province(planCreateRequestDTO.getProvince())
+                .city(planCreateRequestDTO.getCity())
+                .town(planCreateRequestDTO.getTown())
+                .build();
+    }
+}

--- a/src/main/java/trend/project/converter/PlanConverter.java
+++ b/src/main/java/trend/project/converter/PlanConverter.java
@@ -1,9 +1,40 @@
 package trend.project.converter;
 
+import trend.project.api.code.status.ErrorStatus;
+import trend.project.api.exception.handler.PlanCategoryHandler;
 import trend.project.domain.*;
+import trend.project.domain.enumClass.Category;
+import trend.project.domain.enumClass.PlanStatus;
+import trend.project.web.dto.planDTO.PlanDTO;
 import trend.project.web.dto.planDTO.PlanDetailDTO;
 
 public class PlanConverter {
+    
+    public static Plan toCreatePlan(PlanDTO.PlanCreateRequestDTO planCreateRequestDTO) {
+        
+        if (planCreateRequestDTO.getStartDate().isAfter(planCreateRequestDTO.getEndDate())) {
+            throw new PlanCategoryHandler(ErrorStatus.PlAN_END_DATE_INVALID);
+        }
+        
+        Category category;
+        try{
+            category = Category.valueOf(planCreateRequestDTO.getCategory().toUpperCase());
+        } catch (IllegalArgumentException | NullPointerException e) {
+            throw new PlanCategoryHandler(ErrorStatus.CATEGORY_INVALID);}
+        
+        return Plan.builder()
+                .title(planCreateRequestDTO.getTitle())
+                .category(category)
+                .startDate(planCreateRequestDTO.getStartDate())
+                .endDate(planCreateRequestDTO.getEndDate())
+                .target(planCreateRequestDTO.getTarget())
+                .cost(planCreateRequestDTO.getCost())
+                .bookingMethod(planCreateRequestDTO.getBookingMethod())
+                .content(planCreateRequestDTO.getContent())
+                .budget(planCreateRequestDTO.getBudget())
+                .status(PlanStatus.ON_HOLD)
+                .build();
+    }
     
     public static PlanDetailDTO.PlanDetailResponseDTO toPlanDetailResponseDTO(Plan plan,
                                                                               Member member,

--- a/src/main/java/trend/project/domain/Plan.java
+++ b/src/main/java/trend/project/domain/Plan.java
@@ -71,4 +71,8 @@ public class Plan extends BaseEntity {
 
     @OneToMany(mappedBy = "plan",cascade = CascadeType.ALL)
     private List<PlanLikes> planLikes=new ArrayList<>();
+    
+    public void setMember(Member member) {
+        this.member = member;
+    }
 }

--- a/src/main/java/trend/project/service/planService/PlanService.java
+++ b/src/main/java/trend/project/service/planService/PlanService.java
@@ -1,6 +1,7 @@
 package trend.project.service.planService;
 
 import org.springframework.stereotype.Service;
+import trend.project.web.dto.planDTO.PlanDTO;
 import trend.project.web.dto.planDTO.PlanDetailDTO;
 
 import java.util.List;
@@ -9,4 +10,6 @@ import java.util.List;
 public interface PlanService {
     
     PlanDetailDTO.PlanDetailResponseDTO getPlanDetail(Long planId);
+    
+    PlanDTO.PlanCreateResponseDTO planCreate(PlanDTO.PlanCreateRequestDTO req, String username);
 }

--- a/src/main/java/trend/project/service/planService/PlanServiceImpl.java
+++ b/src/main/java/trend/project/service/planService/PlanServiceImpl.java
@@ -4,13 +4,17 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import trend.project.api.code.status.ErrorStatus;
+import trend.project.api.exception.handler.MemberCategoryHandler;
 import trend.project.api.exception.handler.PlanCategoryHandler;
+import trend.project.converter.LocationConverter;
 import trend.project.converter.PlanConverter;
 import trend.project.domain.*;
+import trend.project.repository.MemberRepository;
 import trend.project.repository.planRepository.BannerImageRepository;
 import trend.project.repository.planRepository.LocationRepository;
 import trend.project.repository.planRepository.PlanRepository;
 import trend.project.repository.planRepository.PosterImageRepository;
+import trend.project.web.dto.planDTO.PlanDTO;
 import trend.project.web.dto.planDTO.PlanDetailDTO;
 
 @Service
@@ -22,6 +26,23 @@ public class PlanServiceImpl implements PlanService {
     private final LocationRepository locationRepository;
     private final PosterImageRepository posterImageRepository;
     private final BannerImageRepository bannerImageRepository;
+    private final MemberRepository memberRepository;
+    
+    @Override
+    public PlanDTO.PlanCreateResponseDTO planCreate(PlanDTO.PlanCreateRequestDTO req, String username) {
+        
+        Member findMember = getMemberByUsername(username);
+        
+        Plan newPlan = PlanConverter.toCreatePlan(req);
+        newPlan.setMember(findMember);
+        Plan savedPlan = planRepository.save(newPlan);
+        
+        Location newLocation = LocationConverter.toPlanLocation(req);
+        newLocation.setPlan(savedPlan);
+        locationRepository.save(newLocation);
+        
+        return PlanDTO.PlanCreateResponseDTO.builder().planId(savedPlan.getId()).build();
+    }
     
     @Override
     public PlanDetailDTO.PlanDetailResponseDTO getPlanDetail(Long planId) {
@@ -55,5 +76,10 @@ public class PlanServiceImpl implements PlanService {
         return planRepository.findById(planId).orElseThrow(
                 () -> new PlanCategoryHandler(ErrorStatus.PLAN_NOT_FOUND)
         );
+    }
+    
+    private Member getMemberByUsername(String username){
+        return memberRepository.findByUsername(username)
+                .orElseThrow(()-> new MemberCategoryHandler(ErrorStatus.MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/trend/project/web/controller/planController/PlanController.java
+++ b/src/main/java/trend/project/web/controller/planController/PlanController.java
@@ -3,9 +3,12 @@ package trend.project.web.controller.planController;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import trend.project.api.ApiResponse;
 import trend.project.service.planService.PlanService;
+import trend.project.web.dto.planDTO.PlanDTO;
 import trend.project.web.dto.planDTO.PlanDetailDTO;
 
 @RestController
@@ -18,7 +21,10 @@ public class PlanController {
     
     @Operation(summary = "기획서 생성 API", description = "해당 API는 게시글의 정보를 입력받아 생성합니다.")
     @PostMapping
-    public void createPlan() {
+    public ApiResponse<PlanDTO.PlanCreateResponseDTO> createPlan(@RequestBody PlanDTO.PlanCreateRequestDTO req,
+                                                                 @AuthenticationPrincipal UserDetails user) {
+        PlanDTO.PlanCreateResponseDTO res = planService.planCreate(req, user.getUsername());
+        return ApiResponse.onSuccess(res);
     }
     
     @Operation(summary = "기획서 상세 조회 API", description = "해당 API는 게시글 상세 정보를 조회합니다.")

--- a/src/main/java/trend/project/web/dto/planDTO/PlanDTO.java
+++ b/src/main/java/trend/project/web/dto/planDTO/PlanDTO.java
@@ -1,4 +1,62 @@
 package trend.project.web.dto.planDTO;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.time.LocalDate;
+
 public class PlanDTO {
+    
+    @Getter
+    public static class PlanCreateRequestDTO {
+        
+        @Schema(description = "축제 이름")
+        private String title;
+        
+        @Schema(description = "축제 카테고리")
+        private String category;
+        
+        @Schema(description = "축제 시작일")
+        private LocalDate startDate;
+        
+        @Schema(description = "축제 종료일")
+        private LocalDate endDate;
+        
+        @Schema(description = "축제 대상")
+        private String target;
+        
+        @Schema(description = "축제 참가 비용")
+        private int cost;
+        
+        @Schema(description = "축제 티켓 구매 방식")
+        private String bookingMethod;
+        
+        @Schema(description = "축제 내용")
+        private String content;
+        
+        @Schema(description = "축제 예산")
+        private int budget;
+        
+        /**
+         * 축제 개최 장소
+         **/
+        @Schema(description = "시/도")
+        private String province;
+        
+        @Schema(description = "시/군/구")
+        private String city;
+        
+        @Schema(description = "읍/면/동")
+        private String town;
+        
+    }
+    
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    @Getter
+    public static class PlanCreateResponseDTO {
+        
+        Long planId;
+    }
 }


### PR DESCRIPTION
## Issue

- #25 


## Summary

- 기획서 생성 API 구현

## Describe your code

- 기획서 정보를 받아 작성하는 API 구현하였습니다.

# Check
- [x] Reviewers 등록을 하였나요?
- [x] Assignees 등록을 하였나요?
- [x] 라벨 등록을 하였나요?
- [x] PR 머지하기 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced new error statuses for improved error handling: `CATEGORY_INVALID` and `PLAN_END_DATE_INVALID`.
	- Added functionality for creating plans with validation checks for dates and categories.
	- Enhanced DTOs for plan creation and response, allowing for detailed festival information.
	- New method to associate plans with members during creation.

- **Bug Fixes**
	- Improved error handling for invalid categories and end dates during plan creation.

- **Documentation**
	- Updated API documentation to reflect new request and response structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->