### PR TITLE
[feat] 같은 지역 다른 기획서 조회 API 구현 및 엔드포인트 수정

### DIFF
--- a/src/main/java/trend/project/config/SecurityConfig.java
+++ b/src/main/java/trend/project/config/SecurityConfig.java
@@ -94,7 +94,8 @@ public class SecurityConfig {
                 .requestMatchers("members/join","/login","/companies/join").permitAll()
                 .requestMatchers("/members/find-usernames/emails","/members/find-usernames/phoneNumbers","/companies/find-passwords","/companies/find-usernames").permitAll()
                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/webjars/**").permitAll()// Swagger 관련 경로를 허용
-                .requestMatchers(HttpMethod.GET, "/plans/{planId}").permitAll()
+                .requestMatchers(HttpMethod.GET, "/plans/detail/{planId}").permitAll()
+                .requestMatchers(HttpMethod.GET, "/plans/detail/{planId}/similar").permitAll()
                 .requestMatchers(HttpMethod.GET, "/comments/{id}").permitAll()
                 .requestMatchers(HttpMethod.GET, "/plans/poster/{planId}").permitAll()
                 .requestMatchers(HttpMethod.GET, "/plans/banner/{planId}").permitAll()

--- a/src/main/java/trend/project/converter/PlanConverter.java
+++ b/src/main/java/trend/project/converter/PlanConverter.java
@@ -6,7 +6,6 @@ import trend.project.domain.*;
 import trend.project.domain.enumClass.Category;
 import trend.project.domain.enumClass.PlanStatus;
 import trend.project.web.dto.planDTO.PlanDTO;
-import trend.project.web.dto.planDTO.PlanDetailDTO;
 
 public class PlanConverter {
     
@@ -42,34 +41,4 @@ public class PlanConverter {
                 .status(PlanStatus.ON_HOLD)
                 .build();
     }
-    
-    public static PlanDetailDTO.PlanDetailResponseDTO toPlanDetailResponseDTO(Plan plan,
-                                                                              Member member,
-                                                                              Location location,
-                                                                              PlanPosterImage posterImage,
-                                                                              PlanBannerImage bannerImage) {
-        return PlanDetailDTO.PlanDetailResponseDTO.builder()
-                .title(plan.getTitle())
-                .category(String.valueOf(plan.getCategory()))
-                .startDate(plan.getStartDate())
-                .endDate(plan.getEndDate())
-                .target(plan.getTarget())
-                .cost(plan.getCost())
-                .content(plan.getContent())
-                .budget(plan.getBudget())
-                .likesCount(plan.getLikesCount())
-                .commentCount(plan.getCommentCount())
-                .bookmarkCount(plan.getBookmarkCount())
-                .status(plan.getStatus().name())
-                .posterUrl(posterImage != null ? posterImage.getImageLink() : null)
-                .bannerUrl(bannerImage != null ? bannerImage.getImageLink() : null)
-                .username(member.getName())
-                .followerCount(member.getFollowerCount())
-                .province(location.getProvince())
-                .city(location.getCity())
-                .town(location.getTown())
-                .build();
-    }
-    
-
 }

--- a/src/main/java/trend/project/converter/PlanConverter.java
+++ b/src/main/java/trend/project/converter/PlanConverter.java
@@ -63,7 +63,7 @@ public class PlanConverter {
                 .status(plan.getStatus().name())
                 .posterUrl(posterImage != null ? posterImage.getImageLink() : null)
                 .bannerUrl(bannerImage != null ? bannerImage.getImageLink() : null)
-                .username(member.getNickname())
+                .username(member.getName())
                 .followerCount(member.getFollowerCount())
                 .province(location.getProvince())
                 .city(location.getCity())

--- a/src/main/java/trend/project/converter/PlanDetailConverter.java
+++ b/src/main/java/trend/project/converter/PlanDetailConverter.java
@@ -1,0 +1,50 @@
+package trend.project.converter;
+
+import trend.project.domain.*;
+import trend.project.web.dto.planDTO.PlanDetailDTO;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class PlanDetailConverter {
+    
+    public static PlanDetailDTO.PlanDetailResponseDTO toPlanDetailResponseDTO(Plan plan,
+                                                                              Member member,
+                                                                              Location location,
+                                                                              PlanPosterImage posterImage,
+                                                                              PlanBannerImage bannerImage) {
+        return PlanDetailDTO.PlanDetailResponseDTO.builder()
+                .title(plan.getTitle())
+                .category(String.valueOf(plan.getCategory()))
+                .startDate(plan.getStartDate())
+                .endDate(plan.getEndDate())
+                .target(plan.getTarget())
+                .cost(plan.getCost())
+                .content(plan.getContent())
+                .budget(plan.getBudget())
+                .likesCount(plan.getLikesCount())
+                .commentCount(plan.getCommentCount())
+                .bookmarkCount(plan.getBookmarkCount())
+                .status(plan.getStatus().name())
+                .posterUrl(posterImage != null ? posterImage.getImageLink() : null)
+                .bannerUrl(bannerImage != null ? bannerImage.getImageLink() : null)
+                .username(member.getName())
+                .followerCount(member.getFollowerCount())
+                .province(location.getProvince())
+                .city(location.getCity())
+                .town(location.getTown())
+                .build();
+    }
+    
+    public static List<PlanDetailDTO.SameProvinceOtherPlanResponseDTO> toSameProvinceOtherPlanResponseDTOList(
+            List<Plan> plans) {
+        return plans.stream()
+                .map(plan -> PlanDetailDTO.SameProvinceOtherPlanResponseDTO.builder()
+                        .imageLink(plan.getPlanPosterImage() != null ? plan.getPlanPosterImage().getImageLink() : null)
+                        .title(plan.getTitle())
+                        .name(plan.getMember().getName())
+                        .build())
+                .collect(Collectors.toList());
+    }
+    
+}

--- a/src/main/java/trend/project/domain/Plan.java
+++ b/src/main/java/trend/project/domain/Plan.java
@@ -91,6 +91,11 @@ public class Plan extends BaseEntity {
         this.member = member;
     }
     
+    public void setPlanPosterImage(PlanPosterImage planPosterImage) {
+        this.planPosterImage = planPosterImage;
+        planPosterImage.setPlan(this);
+    }
+    
     public void update(PlanDTO.PlanUpdateRequestDTO dto) {
         Category category = switch (dto.getCategory()) {
             case 1 -> Category.MUSIC_PERFORMANCE;

--- a/src/main/java/trend/project/repository/planRepository/PlanRepository.java
+++ b/src/main/java/trend/project/repository/planRepository/PlanRepository.java
@@ -3,6 +3,7 @@ package trend.project.repository.planRepository;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import trend.project.domain.Member;
 import trend.project.domain.Plan;
 import trend.project.domain.enumClass.Category;
@@ -29,5 +30,14 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
     List<Plan> findTop5ByMember(Member member);
 
     List<Plan> findTop4ByTitleContainingIgnoreCaseOrderByLikesCountDesc(String title);
+    
+    @Query("SELECT p FROM Plan p " +
+            "JOIN p.location l " +
+            "WHERE l.province = :province " +
+            "AND p.id <> :planId " +
+            "ORDER BY p.likesCount DESC")
+    List<Plan> findTop5ByProvinceAndNotCurrentPlanOrderByLikesCountDesc(
+            @Param("province") String province,
+            @Param("planId") Long planId);
 
 }

--- a/src/main/java/trend/project/service/planService/PlanDetailService.java
+++ b/src/main/java/trend/project/service/planService/PlanDetailService.java
@@ -1,0 +1,12 @@
+package trend.project.service.planService;
+
+import trend.project.web.dto.planDTO.PlanDetailDTO;
+
+import java.util.List;
+
+public interface PlanDetailService {
+    
+    PlanDetailDTO.PlanDetailResponseDTO getPlanDetail(Long planId);
+    
+    List<PlanDetailDTO.SameProvinceOtherPlanResponseDTO> getSameProvinceOtherPlans(Long planId);
+}

--- a/src/main/java/trend/project/service/planService/PlanDetailServiceImpl.java
+++ b/src/main/java/trend/project/service/planService/PlanDetailServiceImpl.java
@@ -1,0 +1,83 @@
+package trend.project.service.planService;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import trend.project.api.code.status.ErrorStatus;
+import trend.project.api.exception.handler.MemberCategoryHandler;
+import trend.project.api.exception.handler.PlanCategoryHandler;
+import trend.project.converter.PlanDetailConverter;
+import trend.project.domain.*;
+import trend.project.repository.MemberRepository;
+import trend.project.repository.planRepository.BannerImageRepository;
+import trend.project.repository.planRepository.LocationRepository;
+import trend.project.repository.planRepository.PlanRepository;
+import trend.project.repository.planRepository.PosterImageRepository;
+import trend.project.web.dto.planDTO.PlanDetailDTO;
+
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PlanDetailServiceImpl implements PlanDetailService {
+    
+    private final PlanRepository planRepository;
+    private final LocationRepository locationRepository;
+    private final PosterImageRepository posterImageRepository;
+    private final BannerImageRepository bannerImageRepository;
+    private final MemberRepository memberRepository;
+    
+    @Override
+    public PlanDetailDTO.PlanDetailResponseDTO getPlanDetail(Long planId) {
+        
+        Plan findPlan = findPlanById(planId);
+        Member findMember = findPlan.getMember();
+        Location planLocation = getLocation(planId);
+        PlanPosterImage posterImage = getPosterImage(planId);
+        PlanBannerImage bannerImage = getBannerImage(planId);
+        
+        return PlanDetailConverter.toPlanDetailResponseDTO(findPlan, findMember, planLocation, posterImage, bannerImage);
+    }
+    
+    @Override
+    public List<PlanDetailDTO.SameProvinceOtherPlanResponseDTO> getSameProvinceOtherPlans(Long planId) {
+        Plan findPlan = findPlanById(planId);
+        List<Plan> sameProvincePlans = null;
+        try {
+            sameProvincePlans = planRepository.findTop5ByProvinceAndNotCurrentPlanOrderByLikesCountDesc(
+                    findPlan.getLocation().getProvince(),
+                    planId);
+        } catch (Exception e) {
+            sameProvincePlans = Collections.emptyList();
+        }
+        
+        return PlanDetailConverter.toSameProvinceOtherPlanResponseDTOList(sameProvincePlans);
+    }
+    
+    private PlanBannerImage getBannerImage(Long planId) {
+        return bannerImageRepository.findImagesByPlanId(planId).orElse(null);
+    }
+    
+    private PlanPosterImage getPosterImage(Long planId) {
+        return posterImageRepository.findImagesByPlanId(planId).orElse(null);
+    }
+    
+    private Location getLocation(Long planId) {
+        return locationRepository.findByPlanId(planId).orElseThrow(
+                () -> new PlanCategoryHandler(ErrorStatus.PLAN_LOCATION_NOT_FOUND)
+        );
+    }
+    
+    private Plan findPlanById(Long planId) {
+        return planRepository.findById(planId).orElseThrow(
+                () -> new PlanCategoryHandler(ErrorStatus.PLAN_NOT_FOUND)
+        );
+    }
+    
+    private Member getMemberByUsername(String username){
+        return memberRepository.findByUsername(username)
+                .orElseThrow(()-> new MemberCategoryHandler(ErrorStatus.MEMBER_NOT_FOUND));
+    }
+}

--- a/src/main/java/trend/project/service/planService/PlanPosterServiceImpl.java
+++ b/src/main/java/trend/project/service/planService/PlanPosterServiceImpl.java
@@ -108,8 +108,8 @@ public class PlanPosterServiceImpl implements PlanPosterService {
         PlanPosterImage image = PlanPosterImage.builder()
                 .imageLink(uniqueFileName)
                 .imageName(originalFileName)
-                .plan(findplan)
                 .build();
+        findplan.setPlanPosterImage(image);
         
         posterImageRepository.save(image);
     }

--- a/src/main/java/trend/project/service/planService/PlanService.java
+++ b/src/main/java/trend/project/service/planService/PlanService.java
@@ -9,8 +9,6 @@ import java.util.List;
 @Service
 public interface PlanService {
     
-    PlanDetailDTO.PlanDetailResponseDTO getPlanDetail(Long planId);
-    
     PlanDTO.PlanCreateResponseDTO planCreate(PlanDTO.PlanCreateRequestDTO req, String username);
     
     PlanDTO.PlanUpdateResponseDTO planUpdate(PlanDTO.PlanUpdateRequestDTO req, Long planId, String username);

--- a/src/main/java/trend/project/service/planService/PlanServiceImpl.java
+++ b/src/main/java/trend/project/service/planService/PlanServiceImpl.java
@@ -15,7 +15,6 @@ import trend.project.repository.planRepository.LocationRepository;
 import trend.project.repository.planRepository.PlanRepository;
 import trend.project.repository.planRepository.PosterImageRepository;
 import trend.project.web.dto.planDTO.PlanDTO;
-import trend.project.web.dto.planDTO.PlanDetailDTO;
 
 @Service
 @RequiredArgsConstructor
@@ -24,8 +23,6 @@ public class PlanServiceImpl implements PlanService {
     
     private final PlanRepository planRepository;
     private final LocationRepository locationRepository;
-    private final PosterImageRepository posterImageRepository;
-    private final BannerImageRepository bannerImageRepository;
     private final MemberRepository memberRepository;
     
     @Override
@@ -77,30 +74,10 @@ public class PlanServiceImpl implements PlanService {
         planRepository.delete(findPlan);
     }
     
-    @Override
-    public PlanDetailDTO.PlanDetailResponseDTO getPlanDetail(Long planId) {
-        
-        Plan findPlan = findPlanById(planId);
-        Member findMember = findPlan.getMember();
-        Location planLocation = getLocation(planId);
-        PlanPosterImage posterImage = getPosterImage(planId);
-        PlanBannerImage bannerImage = getBannerImage(planId);
-        
-        return PlanConverter.toPlanDetailResponseDTO(findPlan, findMember, planLocation, posterImage, bannerImage);
-    }
-    
     private Location getLocation(Long planId) {
         return locationRepository.findByPlanId(planId).orElseThrow(
                 () -> new PlanCategoryHandler(ErrorStatus.PLAN_LOCATION_NOT_FOUND)
         );
-    }
-    
-    private PlanBannerImage getBannerImage(Long planId) {
-        return bannerImageRepository.findImagesByPlanId(planId).orElse(null);
-    }
-    
-    private PlanPosterImage getPosterImage(Long planId) {
-        return posterImageRepository.findImagesByPlanId(planId).orElse(null);
     }
     
     private Plan findPlanById(Long planId) {

--- a/src/main/java/trend/project/web/controller/planController/PlanController.java
+++ b/src/main/java/trend/project/web/controller/planController/PlanController.java
@@ -27,13 +27,6 @@ public class PlanController {
         return ApiResponse.onSuccess(res);
     }
     
-    @Operation(summary = "기획서 상세 조회 API", description = "해당 API는 게시글 상세 정보를 조회합니다.")
-    @GetMapping("/{planId}")
-    public ApiResponse<PlanDetailDTO.PlanDetailResponseDTO> getDetailPlan(@PathVariable Long planId) {
-        PlanDetailDTO.PlanDetailResponseDTO planDetail = planService.getPlanDetail(planId);
-        return ApiResponse.onSuccess(planDetail);
-    }
-    
     @Operation(summary = "기획서 수정 API", description = "해당 API는 특정 게시글의 정보를 수정합니다. 권한는 작성자에게 있습니다.")
     @PutMapping("/{planId}")
     public ApiResponse<PlanDTO.PlanUpdateResponseDTO> updatePlan(@RequestBody PlanDTO.PlanUpdateRequestDTO req,
@@ -51,5 +44,4 @@ public class PlanController {
         
         return ApiResponse.onSuccess("기획서가 삭제되었습니다.");
     }
-
 }

--- a/src/main/java/trend/project/web/controller/planController/PlanDetailController.java
+++ b/src/main/java/trend/project/web/controller/planController/PlanDetailController.java
@@ -1,0 +1,37 @@
+package trend.project.web.controller.planController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import trend.project.api.ApiResponse;
+import trend.project.service.planService.PlanDetailServiceImpl;
+import trend.project.web.dto.planDTO.PlanDetailDTO;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/plans/detail")
+@RequiredArgsConstructor
+@Tag(name = "기획서 상세 조회 페이지 API")
+public class PlanDetailController {
+    
+    private final PlanDetailServiceImpl planDetailService;
+    
+    @Operation(summary = "기획서 상세 조회 API", description = "해당 API는 게시글 상세 정보를 조회합니다.")
+    @GetMapping("/{planId}")
+    public ApiResponse<PlanDetailDTO.PlanDetailResponseDTO> getDetailPlan(@PathVariable Long planId) {
+        PlanDetailDTO.PlanDetailResponseDTO planDetail = planDetailService.getPlanDetail(planId);
+        return ApiResponse.onSuccess(planDetail);
+    }
+    
+    @Operation(summary = "같은 지역 기획서 조회 API", description = "해당 API는 조회 기획서와 같은 지역의 다른 기획서를 조회합니다.")
+    @GetMapping("/{planId}/similar")
+    public ApiResponse<List<PlanDetailDTO.SameProvinceOtherPlanResponseDTO>> getSimilarPlan(@PathVariable Long planId) {
+        List<PlanDetailDTO.SameProvinceOtherPlanResponseDTO> planResponseDTOS = planDetailService.getSameProvinceOtherPlans(planId);
+        return ApiResponse.onSuccess(planResponseDTOS);
+    }
+}

--- a/src/main/java/trend/project/web/dto/planDTO/PlanDetailDTO.java
+++ b/src/main/java/trend/project/web/dto/planDTO/PlanDetailDTO.java
@@ -71,4 +71,20 @@ public class PlanDetailDTO {
         @Schema(description = "읍/면/동")
         private String town;
     }
+    
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    @Getter
+    public static class SameProvinceOtherPlanResponseDTO {
+        
+        @Schema(description = "기획자 이름입니다.")
+        private String name;
+        
+        @Schema(description = "기획서 제목입니다.")
+        private String title;
+        
+        @Schema(description = "포스터 이미지 링크입니다.")
+        private String imageLink;
+    }
 }


### PR DESCRIPTION
## Issue

- #46  


## Summary

- 같은 지역 다른 기획서 조회 API 구현 및 엔드포인트 수정

## Describe your code

- 같은 지역 다른 기획서 조회 API 구현하였고 상세페이지 분리에 따라서 엔드포인트의 수정이 있습니다.

# Check
- [x] Reviewers 등록을 하였나요?
- [x] Assignees 등록을 하였나요?
- [x] 라벨 등록을 하였나요?
- [x] PR 머지하기 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!
